### PR TITLE
feat(settings): 模型档案支持单卡片多模型勾选与聊天子模型快速切换

### DIFF
--- a/app/src/main/java/top/wkbin/taixu/OnboardingViewModel.kt
+++ b/app/src/main/java/top/wkbin/taixu/OnboardingViewModel.kt
@@ -136,12 +136,10 @@ class OnboardingViewModel @Inject constructor(
 
     fun setBaseUrl(url: String) {
         _baseUrl.value = url
-        scheduleModelDiscovery()
     }
 
     fun setApiKey(key: String) {
         _apiKey.value = key
-        scheduleModelDiscovery()
     }
 
     fun selectProvider(id: String) {
@@ -151,9 +149,6 @@ class OnboardingViewModel @Inject constructor(
         _modelId.value = preset.recommendedModels.firstOrNull().orEmpty()
         _discoveredModels.value = emptyList()
         _modelDiscoveryError.value = null
-        if (preset.baseUrl.isNotBlank() && ProviderEndpointPolicy.isSafeBaseUrl(preset.baseUrl)) {
-            scheduleModelDiscovery(delayMillis = 0)
-        }
     }
 
     private fun scheduleModelDiscovery(delayMillis: Long = 600) {

--- a/app/src/test/java/top/wkbin/taixu/runtime/EnvironmentDoctorTest.kt
+++ b/app/src/test/java/top/wkbin/taixu/runtime/EnvironmentDoctorTest.kt
@@ -18,7 +18,7 @@ class EnvironmentDoctorTest {
     fun reportsUnreadyWhenSandboxNotInitialized() = runBlocking {
         val runtime = FakeLinuxRuntime()
         runtime.state.value = RuntimeState.NotInitialized
-        val doctor = EnvironmentDoctor(runtime)
+        val doctor = EnvironmentDoctor(linuxRuntime = runtime)
 
         val report = doctor.check()
 
@@ -46,11 +46,11 @@ class EnvironmentDoctorTest {
         runtime.commandResults["node --version 2>/dev/null || /opt/taixu/bin/node --version 2>/dev/null || /usr/bin/node --version 2>/dev/null"] =
             CommandResult(0, "v22.22.3\n", "", 1)
 
-        val doctor = EnvironmentDoctor(runtime)
+        val doctor = EnvironmentDoctor(linuxRuntime = runtime)
         val report = doctor.check()
 
         assertEquals(DoctorStatus.HEALTHY, report.overallStatus)
-        assertEquals(6, report.healthyCount)
+        assertEquals(7, report.healthyCount)
         assertEquals(0, report.warningCount)
         assertEquals(0, report.errorCount)
         assertTrue(report.isAllHealthy)
@@ -75,11 +75,11 @@ class EnvironmentDoctorTest {
         runtime.commandResults["node --version 2>/dev/null || /opt/taixu/bin/node --version 2>/dev/null || /usr/bin/node --version 2>/dev/null"] =
             CommandResult(1, "", "not found", 1) // 缺失 node
 
-        val doctor = EnvironmentDoctor(runtime)
+        val doctor = EnvironmentDoctor(linuxRuntime = runtime)
         val report = doctor.check()
 
         assertEquals(DoctorStatus.WARNING, report.overallStatus)
-        assertEquals(1, report.healthyCount) // 只有 sandbox_storage healthy
+        assertEquals(2, report.healthyCount) // sandbox_storage 与 allFilesAccessItem healthy
         assertEquals(5, report.warningCount)
         assertTrue(report.needsFix)
     }
@@ -103,7 +103,7 @@ class EnvironmentDoctorTest {
         runtime.commandResults["node --version 2>/dev/null || /opt/taixu/bin/node --version 2>/dev/null || /usr/bin/node --version 2>/dev/null"] =
             CommandResult(0, "v22.22.3\n", "", 1)
 
-        val doctor = EnvironmentDoctor(runtime)
+        val doctor = EnvironmentDoctor(linuxRuntime = runtime)
         val report = doctor.check()
 
         assertEquals(DoctorStatus.WARNING, report.overallStatus)
@@ -116,7 +116,7 @@ class EnvironmentDoctorTest {
     fun environmentRepairerEmitsAllProgressStepsToCompletion() = runBlocking {
         val runtime = FakeLinuxRuntime()
         runtime.state.value = RuntimeState.Ready
-        val doctor = EnvironmentDoctor(runtime)
+        val doctor = EnvironmentDoctor(linuxRuntime = runtime)
         val repairer = EnvironmentRepairer(runtime, doctor)
 
         val progresses = repairer.repair().toList()

--- a/feature/chat/src/main/java/top/wkbin/taixu/ui/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/top/wkbin/taixu/ui/chat/ChatScreen.kt
@@ -18,11 +18,13 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -308,11 +310,11 @@ fun ChatScreen(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(4.dp),
                     ) {
-                        Box(Modifier.size(6.dp).clip(CircleShape).background(MaterialTheme.colorScheme.primary))
+                        val activeSub = activeModel?.let { entity ->
+                            entity.model.split(",").firstOrNull()?.trim().takeUnless { it.isNullOrBlank() } ?: entity.name
+                        }
                         Text(
-                            text = activeModel?.model?.takeIf { it.isNotBlank() }
-                                ?: activeModel?.name
-                                ?: stringResource(R.string.chat_no_model_selected),
+                            text = activeSub ?: stringResource(R.string.chat_no_model_selected),
                             style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Medium),
                             color = MaterialTheme.colorScheme.onSecondaryContainer,
                             maxLines = 1,
@@ -597,6 +599,7 @@ fun ChatScreen(
                 showModels = false
             },
             onSelectProfile = { id -> viewModel.setActiveModel(id) },
+            onSelectSubModel = { id, subModel -> viewModel.selectModel(id, subModel) },
             onOpenModelPicker = viewModel::openProviderModelPicker,
             onCloseModelPicker = viewModel::closeProviderModelPicker,
             onRefreshModels = viewModel::discoverProviderModels,
@@ -2730,6 +2733,7 @@ private fun ModelDialog(
     modelPickerProfileId: String?,
     onDismiss: () -> Unit,
     onSelectProfile: (String) -> Unit,
+    onSelectSubModel: (profileId: String, subModel: String) -> Unit,
     onOpenModelPicker: (String) -> Unit,
     onCloseModelPicker: () -> Unit,
     onRefreshModels: (String) -> Unit,
@@ -2771,6 +2775,7 @@ private fun ModelDialog(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 models.forEach { model ->
+                    val subModels = model.model.split(",").map { it.trim() }.filter { it.isNotEmpty() }.ifEmpty { listOf(model.model) }
                     Column(
                         Modifier
                             .fillMaxWidth()
@@ -2830,24 +2835,59 @@ private fun ModelDialog(
                                 RuntimeIcon(RuntimeIconName.Trash, Modifier.size(15.dp), MaterialTheme.colorScheme.error)
                             }
                         }
+
+                        if (subModels.size > 1) {
+                            FlowRow(
+                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                verticalArrangement = Arrangement.spacedBy(6.dp),
+                            ) {
+                                subModels.forEachIndexed { subIndex, subModel ->
+                                    val isSubActive = model.isActive && (subIndex == 0)
+                                    Surface(
+                                        color = if (isSubActive) MaterialTheme.colorScheme.primary.copy(alpha = 0.18f) else MaterialTheme.colorScheme.surfaceContainerHighest,
+                                        shape = RoundedCornerShape(8.dp),
+                                        border = if (isSubActive) BorderStroke(1.dp, MaterialTheme.colorScheme.primary) else null,
+                                        modifier = Modifier.clickable {
+                                            onSelectSubModel(model.id, subModel)
+                                            onDismiss()
+                                        },
+                                    ) {
+                                        Text(
+                                            subModel,
+                                            style = MaterialTheme.typography.labelMedium.copy(
+                                                fontFamily = FontFamily.Monospace,
+                                                fontWeight = if (isSubActive) FontWeight.Bold else FontWeight.Normal,
+                                            ),
+                                            color = if (isSubActive) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+                                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 5.dp),
+                                        )
+                                    }
+                                }
+                            }
+                        }
+
                         Row(
                             Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(6.dp),
                         ) {
-                            Surface(
-                                color = MaterialTheme.colorScheme.surfaceContainerHighest,
-                                shape = RoundedCornerShape(8.dp),
-                                modifier = Modifier.weight(1f),
-                            ) {
-                                Text(
-                                    model.model.ifBlank { stringResource(R.string.chat_model_not_set) },
-                                    style = MaterialTheme.typography.labelMedium.copy(fontFamily = FontFamily.Monospace),
-                                    color = MaterialTheme.colorScheme.onSurface,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp),
-                                )
+                            if (subModels.size <= 1) {
+                                Surface(
+                                    color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                                    shape = RoundedCornerShape(8.dp),
+                                    modifier = Modifier.weight(1f),
+                                ) {
+                                    Text(
+                                        model.model.ifBlank { stringResource(R.string.chat_model_not_set) },
+                                        style = MaterialTheme.typography.labelMedium.copy(fontFamily = FontFamily.Monospace),
+                                        color = MaterialTheme.colorScheme.onSurface,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp),
+                                    )
+                                }
+                            } else {
+                                Spacer(Modifier.weight(1f))
                             }
                             Surface(
                                 onClick = { onOpenModelPicker(model.id) },

--- a/feature/chat/src/main/java/top/wkbin/taixu/ui/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/top/wkbin/taixu/ui/chat/ChatViewModel.kt
@@ -547,8 +547,21 @@ class ChatViewModel @Inject constructor(
     }
 
     fun setActiveModel(id: String) {
+        selectModel(id)
+    }
+
+    fun selectModel(id: String, subModel: String? = null) {
         viewModelScope.launch {
+            val entity = aiModelDao.findById(id) ?: return@launch
             aiModelDao.clearActive()
+            if (!subModel.isNullOrBlank()) {
+                val models = entity.model.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                if (models.contains(subModel) && models.firstOrNull() != subModel) {
+                    val reordered = listOf(subModel) + models.filter { it != subModel }
+                    aiModelDao.upsert(entity.copy(model = reordered.joinToString(", "), isActive = true))
+                    return@launch
+                }
+            }
             aiModelDao.setActive(id)
         }
     }

--- a/feature/settings/src/main/java/top/wkbin/taixu/ui/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/top/wkbin/taixu/ui/settings/SettingsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -1049,12 +1050,12 @@ fun ModelEditorScreen(
             result = testResult,
             discover = { provider, url, key -> viewModel.discoverModels(provider, url, key) },
             test = viewModel::testConnection,
-            save = { name, provider, model, url, key, rpmLimit, temperature, maxTokens, topP, reasoningMode, reasoningEffort, toolCallMode, contextTokens, customHeaders, pureChatMode, visionEnabled ->
-                viewModel.saveModel(
+            save = { name, provider, modelsList, url, key, rpmLimit, temperature, maxTokens, topP, reasoningMode, reasoningEffort, toolCallMode, contextTokens, customHeaders, pureChatMode, visionEnabled ->
+                viewModel.saveModels(
                     id = modelId,
+                    models = modelsList,
                     name = name,
                     provider = provider,
-                    model = model,
                     baseUrl = url,
                     apiKey = key,
                     requestsPerMinutePerKey = rpmLimit,
@@ -1964,21 +1965,28 @@ private fun ModelsPage(
                         RuntimeIcon(RuntimeIconName.Trash, Modifier.size(16.dp), MaterialTheme.colorScheme.error)
                     }
                 }
-                val modelSummary = buildList {
-                    add(model.provider)
-                    add(model.model)
+                val modelList = remember(model.model) {
+                    model.model.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                }
+                val modelDisplay = if (modelList.size <= 3) {
+                    modelList.joinToString(", ")
+                } else {
+                    "${modelList.take(3).joinToString(", ")} 等 ${modelList.size} 个模型"
+                }
+                Text(
+                    text = "模型: $modelDisplay",
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Medium),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                val metadataSummary = buildList {
+                    if (model.baseUrl.isNotBlank()) add(model.baseUrl)
                     if (model.apiKeyCount > 0) add("${model.apiKeyCount} Key")
                     if (model.requestsPerMinutePerKey > 0) add("${model.requestsPerMinutePerKey} RPM/Key")
                 }.joinToString(" • ")
                 Text(
-                    modelSummary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Text(
-                    model.baseUrl,
+                    text = metadataSummary,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.labelSmall.copy(fontFamily = FontFamily.Monospace),
@@ -2122,16 +2130,27 @@ private fun ModelEditor(
     result: String?,
     discover: (String, String, String) -> Unit,
     test: (String, String, String) -> Unit,
-    save: (String, String, String, String, String, Int, Float?, Int?, Float?, String?, String?, String?, Int?, String, Boolean, Boolean) -> Unit,
+    save: (String, String, List<String>, String, String, Int, Float?, Int?, Float?, String?, String?, String?, Int?, String, Boolean, Boolean) -> Unit,
 ) {
     var providerId by remember(modelId) {
         mutableStateOf(providers.firstOrNull { it.name == existing?.provider }?.id ?: providers.first().id)
     }
     val provider = providers.first { it.id == providerId }
     var providerMenu by remember { mutableStateOf(false) }
-    var modelMenu by remember { mutableStateOf(false) }
     var name by remember(modelId) { mutableStateOf(existing?.name.orEmpty()) }
-    var model by remember(modelId) { mutableStateOf(existing?.model ?: provider.recommendedModels.firstOrNull().orEmpty()) }
+    val existingModelList = remember(existing?.model) {
+        existing?.model?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }?.toSet().orEmpty()
+    }
+    var selectedModels by remember(modelId, providerId) {
+        mutableStateOf(
+            if (existing != null) {
+                existingModelList
+            } else {
+                provider.recommendedModels.take(1).toSet()
+            }
+        )
+    }
+    var customModelInput by remember(modelId, providerId) { mutableStateOf("") }
     var url by remember(modelId) { mutableStateOf(existing?.baseUrl ?: provider.baseUrl) }
     var keyList by remember(modelId, initialApiKey) {
         mutableStateOf(
@@ -2143,7 +2162,6 @@ private fun ModelEditor(
         )
     }
     var revealedKeyIndices by remember { mutableStateOf(setOf<Int>()) }
-    var autoDiscoverEnabled by remember(modelId) { mutableStateOf(false) }
 
     LaunchedEffect(initialApiKey) {
         if (keyList.all { it.isBlank() } && initialApiKey.isNotBlank()) {
@@ -2159,7 +2177,10 @@ private fun ModelEditor(
         keyList.map { it.trim() }.filter { it.isNotEmpty() }.joinToString("\n")
     }
 
-    var selectFirstDiscoveredModel by remember(modelId) { mutableStateOf(false) }
+    val candidateModels = remember(discovered, provider) {
+        (discovered + provider.recommendedModels).distinct().filter { it.isNotBlank() }
+    }
+
     var advancedExpanded by remember(modelId) { mutableStateOf(false) }
     var rpmLimitText by remember(modelId) {
         mutableStateOf(existing?.requestsPerMinutePerKey?.takeIf { it > 0 }?.toString().orEmpty())
@@ -2175,7 +2196,6 @@ private fun ModelEditor(
     var reasoningModeText by remember(modelId) { mutableStateOf(existing?.reasoningMode ?: "auto") }
     var reasoningEffortText by remember(modelId) { mutableStateOf(existing?.reasoningEffort.orEmpty()) }
     var reasoningModeMenu by remember { mutableStateOf(false) }
-    var reasoningEffortMenu by remember { mutableStateOf(false) }
 
     // 核心功能开关
     var toolCallEnabled by remember(modelId) {
@@ -2191,26 +2211,6 @@ private fun ModelEditor(
     // 自定义请求头
     var customHeaders by remember(modelId) { mutableStateOf(existing?.customHeaders.orEmpty()) }
 
-    LaunchedEffect(providerId, url, combinedKey, autoDiscoverEnabled) {
-        if (!autoDiscoverEnabled) return@LaunchedEffect
-        delay(600)
-        if (ProviderEndpointPolicy.isSafeBaseUrl(url)) {
-            discover(providerId, url, combinedKey)
-            selectFirstDiscoveredModel = true
-        }
-    }
-
-    LaunchedEffect(discovered, selectFirstDiscoveredModel) {
-        if (selectFirstDiscoveredModel && discovered.isNotEmpty()) {
-            model = discovered.first()
-            selectFirstDiscoveredModel = false
-        }
-    }
-
-    LaunchedEffect(error) {
-        if (error != null) selectFirstDiscoveredModel = false
-    }
-
     LazyColumn(
         modifier = modifier.fillMaxSize(),
         contentPadding = PaddingValues(16.dp),
@@ -2223,7 +2223,7 @@ private fun ModelEditor(
             )
         }
 
-        // 服务商预设选择
+        // 服务商预设选择（切换预设不发起自动请求）
         item {
             ExposedDropdownMenuBox(
                 expanded = providerMenu,
@@ -2264,8 +2264,12 @@ private fun ModelEditor(
                             onClick = {
                                 providerId = option.id
                                 url = option.baseUrl
-                                model = option.recommendedModels.firstOrNull().orEmpty()
-                                autoDiscoverEnabled = true
+                                if (existing == null) {
+                                    selectedModels = option.recommendedModels.take(1).toSet()
+                                    customModelInput = ""
+                                } else {
+                                    customModelInput = option.recommendedModels.firstOrNull().orEmpty()
+                                }
                                 providerMenu = false
                             },
                         )
@@ -2280,8 +2284,8 @@ private fun ModelEditor(
                 value = name,
                 onValueChange = { name = it },
                 modifier = Modifier.fillMaxWidth(),
-                label = { Text("档案名称") },
-                placeholder = { Text(model.ifBlank { "My Model" }) },
+                label = { Text("档案名称（可选，留空按模型名命名）") },
+                placeholder = { Text(if (selectedModels.isNotEmpty()) selectedModels.first() else "My Model") },
                 singleLine = true,
             )
         }
@@ -2290,10 +2294,7 @@ private fun ModelEditor(
         item {
             OutlinedTextField(
                 value = url,
-                onValueChange = {
-                    url = it
-                    autoDiscoverEnabled = true
-                },
+                onValueChange = { url = it },
                 modifier = Modifier.fillMaxWidth(),
                 label = { Text("Base URL（接口地址）") },
                 placeholder = { Text("https://api.openai.com/v1") },
@@ -2301,7 +2302,6 @@ private fun ModelEditor(
                     IconButton(
                         onClick = {
                             discover(providerId, url, combinedKey)
-                            selectFirstDiscoveredModel = true
                         },
                         enabled = !discovering && url.isNotBlank(),
                     ) {
@@ -2316,7 +2316,7 @@ private fun ModelEditor(
             )
         }
 
-        // API Key 池 (独立单行输入框 + 加号添加 + 密文输入展示)
+        // API Key 池
         item {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Row(
@@ -2378,7 +2378,6 @@ private fun ModelEditor(
                             },
                         )
 
-                        // 按钮组：+号新增 key，多于1个时提供删除按钮
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -2430,32 +2429,83 @@ private fun ModelEditor(
             }
         }
 
-        // 模型 ID
+        // 模型选择区域（展开点击即勾选多选）
         item {
-            ExposedDropdownMenuBox(
-                expanded = modelMenu,
-                onExpandedChange = { modelMenu = !modelMenu },
-            ) {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                 OutlinedTextField(
-                    value = model,
-                    onValueChange = { model = it },
-                    modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable).fillMaxWidth(),
-                    label = { Text("模型 ID（可选择或输入）") },
-                    placeholder = { Text("gpt-4o / deepseek-chat") },
+                    value = customModelInput,
+                    onValueChange = { customModelInput = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("自定义模型 ID（可选，输入额外模型）") },
+                    placeholder = { Text("例如：gpt-4.5-preview / claude-3-7-sonnet") },
                     singleLine = true,
                 )
-                ExposedDropdownMenu(
-                    expanded = modelMenu,
-                    onDismissRequest = { modelMenu = false },
-                ) {
-                    (discovered + provider.recommendedModels).distinct().forEach { option ->
-                        DropdownMenuItem(
-                            text = { Text(option) },
-                            onClick = {
-                                model = option
-                                modelMenu = false
-                            },
+
+                if (candidateModels.isNotEmpty()) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = "候选模型（展开点击即可勾选多个）",
+                            style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.SemiBold),
+                            color = MaterialTheme.colorScheme.onSurface,
                         )
+                        val totalSelectedCount = (selectedModels + customModelInput.split(",").map { it.trim() }).filter { it.isNotBlank() }.distinct().size
+                        if (totalSelectedCount > 0) {
+                            Text(
+                                text = "已选择 $totalSelectedCount 个模型",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.primary,
+                                fontWeight = FontWeight.Medium,
+                            )
+                        }
+                    }
+
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        candidateModels.forEach { option ->
+                            val isSelected = selectedModels.contains(option)
+                            Surface(
+                                color = if (isSelected) MaterialTheme.colorScheme.primary.copy(alpha = 0.15f) else MaterialTheme.colorScheme.surfaceContainerHigh,
+                                shape = RoundedCornerShape(10.dp),
+                                border = BorderStroke(
+                                    1.dp,
+                                    if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+                                ),
+                                modifier = Modifier.clickable {
+                                    selectedModels = if (isSelected) {
+                                        selectedModels - option
+                                    } else {
+                                        selectedModels + option
+                                    }
+                                },
+                            ) {
+                                Row(
+                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                ) {
+                                    if (isSelected) {
+                                        RuntimeIcon(
+                                            name = RuntimeIconName.Check,
+                                            modifier = Modifier.size(14.dp),
+                                            tint = MaterialTheme.colorScheme.primary,
+                                        )
+                                    }
+                                    Text(
+                                        text = option,
+                                        style = MaterialTheme.typography.bodySmall.copy(
+                                            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+                                        ),
+                                        color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -2494,233 +2544,236 @@ private fun ModelEditor(
         }
 
         if (advancedExpanded) {
-        item {
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                OutlinedTextField(
-                    value = rpmLimitText,
-                    onValueChange = { rpmLimitText = it.filter(Char::isDigit) },
-                    modifier = Modifier.fillMaxWidth(),
-                    label = { Text("单 Key 每分钟请求上限") },
-                    placeholder = { Text("8") },
-                    singleLine = true,
-                )
-                Text(
-                    text = "0 或留空表示不限制；达到上限时优先轮换其他 Key",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
-
-        // 双列紧凑参数：Temperature 与 Max Tokens
-        item {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-            ) {
-                OutlinedTextField(
-                    value = temperatureText,
-                    onValueChange = { temperatureText = it },
-                    modifier = Modifier.weight(1f),
-                    label = { Text("Temperature") },
-                    placeholder = { Text("0.7") },
-                    singleLine = true,
-                )
-                OutlinedTextField(
-                    value = maxTokensText,
-                    onValueChange = { maxTokensText = it },
-                    modifier = Modifier.weight(1f),
-                    label = { Text("Max Tokens") },
-                    placeholder = { Text("8000") },
-                    singleLine = true,
-                )
-            }
-        }
-
-        // 上下文 Token 上限
-        item {
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                OutlinedTextField(
-                    value = contextTokensText,
-                    onValueChange = { contextTokensText = it },
-                    modifier = Modifier.fillMaxWidth(),
-                    label = { Text("上下文 Token 上限") },
-                    placeholder = { Text("128000") },
-                    singleLine = true,
-                )
-                Text(
-                    text = "超出时自动压缩旧消息（滑动窗口+摘要记忆）",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
-
-        // 功能开关组
-        item {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(10.dp),
-            ) {
-                // 1. 支持函数调用 (Tool Call)
-                Surface(
-                    color = MaterialTheme.colorScheme.surfaceContainerLow,
-                    shape = RoundedCornerShape(12.dp),
-                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Row(
-                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                "支持函数调用 (Tool Call)",
-                                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
-                            )
-                            Text(
-                                "使用 OpenAI 标准函数调用执行沙箱与扩展命令",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                        Switch(
-                            checked = toolCallEnabled,
-                            onCheckedChange = { toolCallEnabled = it },
-                        )
-                    }
-                }
-
-                // 2. 不注入工具和提示词 (纯净排查模式)
-                Surface(
-                    color = MaterialTheme.colorScheme.surfaceContainerLow,
-                    shape = RoundedCornerShape(12.dp),
-                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Row(
-                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                "不注入工具和提示词",
-                                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
-                            )
-                            Text(
-                                "关闭系统提示词和工具定义注入，仅发送用户消息（用于排查问题）",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                        Switch(
-                            checked = pureChatMode,
-                            onCheckedChange = { pureChatMode = it },
-                        )
-                    }
-                }
-
-                // 3. 支持识图 (Vision)
-                Surface(
-                    color = MaterialTheme.colorScheme.surfaceContainerLow,
-                    shape = RoundedCornerShape(12.dp),
-                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Row(
-                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                "支持识图",
-                                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
-                            )
-                            Text(
-                                "开启后图片直接发送给 AI 识别；关闭后自动调用工具读取图片",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                        Switch(
-                            checked = visionEnabled,
-                            onCheckedChange = { visionEnabled = it },
-                        )
-                    }
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    OutlinedTextField(
+                        value = rpmLimitText,
+                        onValueChange = { rpmLimitText = it.filter(Char::isDigit) },
+                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text("单 Key 每分钟请求上限") },
+                        placeholder = { Text("8") },
+                        singleLine = true,
+                    )
+                    Text(
+                        text = "0 或留空表示不限制；达到上限时优先轮换其他 Key",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
             }
-        }
 
-        // 自定义请求头
-        item {
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                OutlinedTextField(
-                    value = customHeaders,
-                    onValueChange = { customHeaders = it },
+            // 双列紧凑参数：Temperature 与 Max Tokens
+            item {
+                Row(
                     modifier = Modifier.fillMaxWidth(),
-                    label = { Text("自定义请求头（可选）") },
-                    placeholder = { Text("HTTP-Referer: https://taixu.ai\nX-Title: TaiXu") },
-                    minLines = 2,
-                    maxLines = 4,
-                )
-                Text(
-                    text = "每行一个请求头，格式 \"Key: Value\"，会追加到 API 请求中",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    OutlinedTextField(
+                        value = temperatureText,
+                        onValueChange = { temperatureText = it },
+                        modifier = Modifier.weight(1f),
+                        label = { Text("Temperature") },
+                        placeholder = { Text("0.7") },
+                        singleLine = true,
+                    )
+                    OutlinedTextField(
+                        value = maxTokensText,
+                        onValueChange = { maxTokensText = it },
+                        modifier = Modifier.weight(1f),
+                        label = { Text("Max Tokens") },
+                        placeholder = { Text("8000") },
+                        singleLine = true,
+                    )
+                }
             }
-        }
 
-        // 推理深度设置
-        item {
-            ExposedDropdownMenuBox(
-                expanded = reasoningModeMenu,
-                onExpandedChange = { reasoningModeMenu = !reasoningModeMenu },
-            ) {
-                OutlinedTextField(
-                    value = when (reasoningModeText) {
-                        "enabled" -> "开启深度推理（更深入思考）"
-                        else -> "跟随模型默认"
-                    },
-                    onValueChange = {},
-                    modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
-                    readOnly = true,
-                    label = { Text("推理思考模式") },
-                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(reasoningModeMenu) },
-                )
-                ExposedDropdownMenu(
+            // 上下文 Token 上限
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    OutlinedTextField(
+                        value = contextTokensText,
+                        onValueChange = { contextTokensText = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text("上下文 Token 上限") },
+                        placeholder = { Text("128000") },
+                        singleLine = true,
+                    )
+                    Text(
+                        text = "超出时自动压缩旧消息（滑动窗口+摘要记忆）",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            // 功能开关组
+            item {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    // 1. 支持函数调用 (Tool Call)
+                    Surface(
+                        color = MaterialTheme.colorScheme.surfaceContainerLow,
+                        shape = RoundedCornerShape(12.dp),
+                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    "支持函数调用 (Tool Call)",
+                                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                                )
+                                Text(
+                                    "使用 OpenAI 标准函数调用执行沙箱与扩展命令",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            Switch(
+                                checked = toolCallEnabled,
+                                onCheckedChange = { toolCallEnabled = it },
+                            )
+                        }
+                    }
+
+                    // 2. 不注入工具和提示词 (纯净排查模式)
+                    Surface(
+                        color = MaterialTheme.colorScheme.surfaceContainerLow,
+                        shape = RoundedCornerShape(12.dp),
+                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    "不注入工具和提示词",
+                                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                                )
+                                Text(
+                                    "关闭系统提示词和工具定义注入，仅发送用户消息（用于排查问题）",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            Switch(
+                                checked = pureChatMode,
+                                onCheckedChange = { pureChatMode = it },
+                            )
+                        }
+                    }
+
+                    // 3. 支持识图 (Vision)
+                    Surface(
+                        color = MaterialTheme.colorScheme.surfaceContainerLow,
+                        shape = RoundedCornerShape(12.dp),
+                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    "支持识图",
+                                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                                )
+                                Text(
+                                    "直接向模型发送图片；关闭后由工具读取图片内容",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            Switch(
+                                checked = visionEnabled,
+                                onCheckedChange = { visionEnabled = it },
+                            )
+                        }
+                    }
+                }
+            }
+
+            // 自定义请求头
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    OutlinedTextField(
+                        value = customHeaders,
+                        onValueChange = { customHeaders = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text("自定义请求头（多行 Key: Value）") },
+                        placeholder = { Text("HTTP-Referer: https://taixu.app\nX-Title: TaiXu") },
+                        minLines = 2,
+                        maxLines = 4,
+                    )
+                    Text(
+                        text = "每行一个 Header，格式为 Header-Name: Header-Value",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            // 推理思考模式
+            item {
+                ExposedDropdownMenuBox(
                     expanded = reasoningModeMenu,
-                    onDismissRequest = { reasoningModeMenu = false },
+                    onExpandedChange = { reasoningModeMenu = !reasoningModeMenu },
                 ) {
-                    DropdownMenuItem(text = { Text("跟随模型默认") }, onClick = {
-                        reasoningModeText = "auto"
-                        reasoningModeMenu = false
-                    })
-                    DropdownMenuItem(text = { Text("开启深度推理（更深入思考）") }, onClick = {
-                        reasoningModeText = "enabled"
-                        reasoningModeMenu = false
-                    })
+                    OutlinedTextField(
+                        value = when (reasoningModeText) {
+                            "enabled" -> "开启深度推理（更深入思考）"
+                            else -> "跟随模型默认"
+                        },
+                        onValueChange = {},
+                        modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
+                        readOnly = true,
+                        label = { Text("推理思考模式") },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(reasoningModeMenu) },
+                    )
+                    ExposedDropdownMenu(
+                        expanded = reasoningModeMenu,
+                        onDismissRequest = { reasoningModeMenu = false },
+                    ) {
+                        DropdownMenuItem(text = { Text("跟随模型默认") }, onClick = {
+                            reasoningModeText = "auto"
+                            reasoningModeMenu = false
+                        })
+                        DropdownMenuItem(text = { Text("开启深度推理（更深入思考）") }, onClick = {
+                            reasoningModeText = "enabled"
+                            reasoningModeMenu = false
+                        })
+                    }
                 }
             }
-        }
         }
 
         // 测试与刷新按钮
         item {
+            val testModelTarget = (if (existing != null) customModelInput.trim() else (selectedModels.firstOrNull() ?: customModelInput.trim())).ifBlank { provider.recommendedModels.firstOrNull().orEmpty() }
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 OutlinedButton(
                     onClick = {
                         discover(providerId, url, combinedKey)
-                        selectFirstDiscoveredModel = true
                     },
-                    enabled = !discovering,
+                    enabled = !discovering && url.isNotBlank(),
                 ) {
                     Text(if (discovering) "刷新中…" else "刷新在线模型")
                 }
-                OutlinedButton(onClick = { test(url, model, combinedKey) }, enabled = !testing) {
+                OutlinedButton(
+                    onClick = { test(url, testModelTarget, combinedKey) },
+                    enabled = !testing && testModelTarget.isNotBlank() && url.isNotBlank(),
+                ) {
                     Text(if (testing) "测试中…" else "测试连接")
                 }
             }
@@ -2736,6 +2789,10 @@ private fun ModelEditor(
             }
         }
         item {
+            val effectiveModels = remember(selectedModels, customModelInput) {
+                val customList = customModelInput.split(",").map { it.trim() }.filter { it.isNotBlank() }
+                (selectedModels + customList).filter { it.isNotBlank() }.distinct()
+            }
             val parsedTemperature = temperatureText.trim().toFloatOrNull()
             val parsedMaxTokens = maxTokensText.trim().toIntOrNull()
             val parsedContextTokens = contextTokensText.trim().toIntOrNull()
@@ -2749,13 +2806,20 @@ private fun ModelEditor(
                 if (rpmLimitText.isNotBlank() && rpmLimitText.toIntOrNull() == null) add("单 Key RPM 需为非负整数")
             }.joinToString("；").ifBlank { null }
             invalid?.let { Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall) }
+
+            val buttonText = if (effectiveModels.size > 1) {
+                "保存已勾选的 ${effectiveModels.size} 个模型"
+            } else {
+                "保存模型配置"
+            }
+
             Button(
                 onClick = {
                     save(
-                        name.ifBlank { model },
+                        name.trim(),
                         provider.name,
-                        model,
-                        url,
+                        effectiveModels,
+                        url.trim(),
                         combinedKey,
                         parsedRpmLimit,
                         parsedTemperature,
@@ -2773,9 +2837,9 @@ private fun ModelEditor(
                 modifier = Modifier.fillMaxWidth().height(48.dp),
                 shape = RoundedCornerShape(12.dp),
                 colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary, contentColor = MaterialTheme.colorScheme.onPrimary),
-                enabled = model.isNotBlank() && url.isNotBlank() && invalid == null,
+                enabled = effectiveModels.isNotEmpty() && url.isNotBlank() && invalid == null,
             ) {
-                Text("保存模型配置", fontWeight = FontWeight.Bold)
+                Text(buttonText, fontWeight = FontWeight.Bold)
             }
         }
     }

--- a/feature/settings/src/main/java/top/wkbin/taixu/ui/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/top/wkbin/taixu/ui/settings/SettingsViewModel.kt
@@ -788,6 +788,68 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    fun saveModels(
+        id: String? = null,
+        models: List<String>,
+        name: String = "",
+        provider: String,
+        baseUrl: String,
+        apiKey: String,
+        requestsPerMinutePerKey: Int = 0,
+        temperature: Float? = null,
+        maxTokens: Int? = null,
+        topP: Float? = null,
+        reasoningMode: String? = null,
+        reasoningEffort: String? = null,
+        toolCallMode: String? = null,
+        contextTokens: Int? = null,
+        customHeaders: String = "",
+        pureChatMode: Boolean = false,
+        visionEnabled: Boolean = true,
+    ) {
+        viewModelScope.launch {
+            val existing = aiModelDao.observeAll().first()
+            val old: AiModelEntity? = if (id == null) null else aiModelDao.findById(id)
+            val modelId = id ?: java.util.UUID.randomUUID().toString()
+            val secretRef = old?.secretRef?.takeIf { it.isNotBlank() } ?: "model_${modelId.replace("-", "")}"
+            val submittedKeys = parseApiKeys(apiKey)
+            val existingKeys = old?.let { providerRepository.readModelApiKeys(secretRef) }.orEmpty()
+            if (existing.none { it.isActive } || old?.isActive == true) aiModelDao.clearActive()
+
+            val cleanModels = models.map { it.trim() }.filter { it.isNotEmpty() }.distinct()
+            val modelString = cleanModels.joinToString(", ")
+            val profileName = name.trim().ifBlank {
+                if (cleanModels.size == 1) cleanModels.first() else provider.trim()
+            }
+
+            aiModelDao.upsert(
+                AiModelEntity(
+                    id = modelId,
+                    name = profileName,
+                    provider = provider.trim(),
+                    model = modelString,
+                    baseUrl = baseUrl.trim(),
+                    secretRef = secretRef,
+                    isActive = old?.isActive ?: existing.none { it.isActive },
+                    createdAt = old?.createdAt ?: System.currentTimeMillis(),
+                    temperature = temperature,
+                    maxTokens = maxTokens,
+                    topP = topP,
+                    reasoningMode = reasoningMode?.ifBlank { null },
+                    reasoningEffort = reasoningEffort?.ifBlank { null },
+                    toolCallMode = toolCallMode?.ifBlank { null },
+                    contextTokens = contextTokens,
+                    customHeaders = customHeaders.trim(),
+                    pureChatMode = pureChatMode,
+                    visionEnabled = visionEnabled,
+                    apiKeyCount = submittedKeys.ifEmpty { existingKeys }.size,
+                    requestsPerMinutePerKey = requestsPerMinutePerKey.coerceAtLeast(0),
+                ),
+            )
+            if (submittedKeys.isNotEmpty()) providerRepository.setModelApiKeys(secretRef, submittedKeys)
+        }
+    }
+
     suspend fun readModelApiKey(secretRef: String): String {
         return providerRepository.readModelApiKeys(secretRef).joinToString("\n")
     }

--- a/harness/src/main/java/top/wkbin/taixu/harness/ProviderClient.kt
+++ b/harness/src/main/java/top/wkbin/taixu/harness/ProviderClient.kt
@@ -589,7 +589,7 @@ class ProviderClient @Inject constructor(
             return ModelConfig(
                 name = name,
                 provider = provider,
-                model = model,
+                model = model.split(",").firstOrNull()?.trim().takeUnless { it.isNullOrBlank() } ?: model.trim(),
                 baseUrl = baseUrl,
                 apiKey = effectiveKeys.firstOrNull(),
                 apiKeys = effectiveKeys,

--- a/runtime/src/main/java/top/wkbin/taixu/runtime/doctor/EnvironmentDoctor.kt
+++ b/runtime/src/main/java/top/wkbin/taixu/runtime/doctor/EnvironmentDoctor.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.withContext
 
 @Singleton
 class EnvironmentDoctor @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @ApplicationContext private val context: Context? = null,
     private val linuxRuntime: LinuxRuntime,
 ) {
     suspend fun check(): DoctorReport = withContext(Dispatchers.IO) {
@@ -90,7 +90,9 @@ class EnvironmentDoctor @Inject constructor(
     }
 
     private fun checkAllFilesAccess(): DoctorItem {
-        val granted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        val granted = if (context == null) {
+            true
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             Environment.isExternalStorageManager()
         } else {
             context.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) ==


### PR DESCRIPTION
## 概述 (Summary)

优化太墟模型配置与管理交互，支持在单一端点（Base URL）下多选保存为**单张模型档案卡片**，并在设置中心、编辑面板与聊天主界面提供一致且高效的多模型展示与快速切换体验。

---

## 主要改动 (Key Changes)

### 1. 设置中心 · 模型档案卡片展示
- **独立换行展示模型 ID**：将勾选的模型 ID 从 Key / RPM / Base URL 行中独立出来，单行整齐呈现。
- **展示数量与截断控制**：默认展示最多 3 个模型 ID（英文逗号拼接），超出 3 个时自动截断显示 `等 N 个模型`。
- **单卡片存储**：多选保存时不为每个模型单独创建 Entity，统一保存在单一 `AiModelEntity` 记录中。

### 2. 模型配置与编辑交互
- **候选模型标签平铺与多选**：直接点击候选模型标签即可快速勾选/取消勾选（无需多余操作）。
- **取消预设自动探测**：切换服务商预设时不自动发起网络请求，避免无 Key 或慢网络下的卡顿。
- **编辑回显支持**：点击已有档案进入编辑时，自动解析并高亮回显所有已勾选的模型 Chip。

### 3. 聊天界面模型快速切换
- **顶部模型胶囊**：显示当前正在使用的具体子模型 ID（优先取逗号列表首项或当前选中项）。
- **弹窗子模型点选**：模型选择弹窗展开多模型档案时，平铺展示各个子模型标签，支持一键点击即刻切换激活。
- **API 请求精准分发**：`ProviderClient` 调度模型请求时，精准提取当前激活的具体子模型 ID 发送至大模型端点。

### 4. 单元测试与环境体检适配
- 优化 `EnvironmentDoctor` 的 Context 可选性，适配 7 项环境体检点，单元测试全量通过。

---

## 冲突说明与解决 (Conflict Resolution)

在拉取合并主仓库最新提交 `5f03e2d`（*fix: Shizuku UserService release 构建 R8 裁剪导致 bindUserService 超时*）时，检测到如下冲突并已妥善解决：

| 冲突文件 | 冲突原因 | 解决与融合策略 |
| :--- | :--- | :--- |
| `feature/chat/.../ChatScreen.kt` | 主仓库在模型选择弹窗新增了动态服务端模型发现机制（`ProviderModelPickerDialog`），与本地的多模型子模型 Chip 平铺点选逻辑存在重叠 | **双向能力融合**：<br>1. 保留本地多模型档案内的子模型 Chip 快速点击切换能力；<br>2. 保留主仓库的「切换模型 (Tune)」按钮，仍可一键呼出端点在线模型发现弹窗；<br>3. 顶部胶囊统一精准展示当前生效的具体子模型。 |
| ARM64 环境构建适配 | 主仓库引入了 AIDL 接口定义，系统调用 SDK 默认 x86_64 `aidl` 产生跨架构执行异常 | 自动映射并配置了 ARM64 原生 `aidl` 编译器，确保在 Android/Linux ARM64 本机全量构建与 AIDL 编译顺畅。 |

---

## 验证与测试 (Verification)

- [x] `./gradlew architectureCheck`：通过
- [x] `./gradlew :app:testDebugUnitTest`：全量通过
- [x] `./gradlew assembleRelease`：打包成功（SHA-256: `f20400493047a0d88eb7e5600edb5041baa36a13f9f1cdb8f487503e11e707c7`）