### PR TITLE
fix: 修复 Web 协作与浏览器截图的资源泄漏，并给 RTK 输出压缩加语义护栏

### DIFF
--- a/harness/src/main/java/top/wkbin/taixu/harness/RtkCommandOptimizer.kt
+++ b/harness/src/main/java/top/wkbin/taixu/harness/RtkCommandOptimizer.kt
@@ -5,6 +5,13 @@ package top.wkbin.taixu.harness
  * MCP, process, or file-tool behaviour. RTK itself decides whether a supported
  * command has an equivalent; a missing/incompatible binary always falls back to
  * the exact original command in the same shell invocation.
+ *
+ * 两条硬约束：
+ * 1. 改写只允许影响“给人/模型看”的输出。任何输出会被下游脚本解析的命令
+ *    （`ls -1`、`grep -l`、`find -print0`、`git --porcelain` 等）必须原样执行，
+ *    否则 Agent 后续的解析步骤会静默拿到压缩后的文本。
+ * 2. 改写必须零收益即零成本。RTK 没有对应子命令的可执行文件不进入白名单，
+ *    避免为一次注定回退的 `rtk rewrite` 白付两次进程启动。
  */
 internal object RtkCommandOptimizer {
     private const val RTK_BINARY = "/opt/taixu/bin/rtk"
@@ -16,16 +23,53 @@ internal object RtkCommandOptimizer {
         "XDG_DATA_HOME" to "/opt/taixu/data/rtk/data",
     )
 
+    /**
+     * 只保留 RTK 真正提供等价子命令、且压缩确有收益的可执行文件。
+     *
+     * 已移除：`wc`（单文件调用丢弃文件名、总计行被改写成 `Σ`，输出本身就是给脚本读的数字）、
+     * `du` / `yarn` / `bun` / `mvnw`（RTK 无对应子命令，改写只会多付两次进程启动）。
+     */
     private val supportedCommands = setOf(
-        "git", "rg", "grep", "find", "ls", "tree", "wc", "du",
-        "gradle", "gradlew", "mvn", "mvnw", "cargo", "go", "pytest",
-        "npm", "pnpm", "yarn", "bun", "npx",
+        "git", "rg", "grep", "find", "ls", "tree",
+        "gradle", "gradlew", "mvn", "mvnd", "cargo", "go", "pytest",
+        "npm", "pnpm", "npx",
     )
 
-    /** Shell operators, expansions and globs are intentionally left untouched. */
-    private val unsupportedShellSyntax = setOf(
-        '&', '|', ';', '\n', '\r', '<', '>', '`', '$', '*', '?', '[', ']', '{', '}', '~',
+    /**
+     * 只排除会改变命令结构的元字符：管道、串联、重定向、命令替换与换行。
+     *
+     * 通配符与花括号不在此列：`rtk rewrite` 输出会原样保留原命令的引号，随后的 `eval`
+     * 只做一次展开，与直接执行原命令等价。放行它们才能覆盖 Agent 最常用、
+     * 同时压缩收益最高的形态（`find . -name '*.kt'`、`rg -n pattern --glob '*.kt'`）。
+     */
+    private val unsupportedShellSyntax = setOf('&', '|', ';', '\n', '\r', '<', '>', '`', '$')
+
+    /** 与具体命令无关的“机器可解析输出”标志。 */
+    private val universalRawOutputFlags = setOf("--json", "-z", "--null", "--print0")
+
+    /** grep 与 rg 共用：这些标志下输出是给脚本读的（退出码、计数、纯文件名列表）。 */
+    private val grepRawOutputFlags = setOf(
+        "-q", "--quiet", "--silent",
+        "-c", "--count",
+        "-l", "--files-with-matches",
+        "-L", "--files-without-match",
+        "-o", "--only-matching",
+        "--vimgrep",
     )
+
+    /**
+     * 按命令区分的机器可解析标志。必须按命令区分而不是全局匹配：
+     * `ls -l` 是压缩收益最高的形态之一，`grep -l` 却只输出文件名列表。
+     */
+    private val rawOutputFlags = mapOf(
+        "ls" to setOf("-1"),
+        "grep" to grepRawOutputFlags,
+        "rg" to grepRawOutputFlags,
+        "find" to setOf("-print0", "-printf", "-fprint", "-fprint0", "-exec", "-execdir", "-ok", "-okdir"),
+        "git" to setOf("--porcelain", "--numstat", "--name-only", "--name-status", "--format", "--pretty", "--raw"),
+    )
+
+    private val whitespace = Regex("\\s+")
 
     data class PreparedCommand(
         val commandLine: String,
@@ -43,15 +87,26 @@ internal object RtkCommandOptimizer {
     private fun isEligible(command: String): Boolean {
         val trimmed = command.trim()
         if (trimmed.isEmpty() || command.any { it in unsupportedShellSyntax }) return false
-        val executable = trimmed.substringBeforeFirstWhitespace()
-            .substringAfterLast('/')
-            .lowercase()
-        return executable in supportedCommands
+        val tokens = trimmed.split(whitespace)
+        val executable = tokens.first().substringAfterLast('/').lowercase()
+        if (executable !in supportedCommands) return false
+        return !producesMachineReadableOutput(executable, tokens)
     }
 
-    private fun String.substringBeforeFirstWhitespace(): String {
-        val index = indexOfFirst(Char::isWhitespace)
-        return if (index >= 0) substring(0, index) else this
+    /**
+     * 分词只按空白切分：结构性元字符已在 [isEligible] 前置排除，引号内的空格最多
+     * 让某个参数被误判成标志，结果是保守地放弃改写，不会造成语义破坏。
+     */
+    private fun producesMachineReadableOutput(executable: String, tokens: List<String>): Boolean {
+        val flags = rawOutputFlags[executable].orEmpty() + universalRawOutputFlags
+        return tokens.drop(1).any { token -> isRawOutputFlag(token, flags) }
+    }
+
+    private fun isRawOutputFlag(token: String, flags: Set<String>): Boolean {
+        val name = token.substringBefore('=')
+        if (name in flags) return true
+        val isShortCluster = name.length > 2 && name.startsWith('-') && !name.startsWith("--")
+        return isShortCluster && name.drop(1).any { "-$it" in flags }
     }
 
     private fun wrapWithFallback(command: String): String {
@@ -60,7 +115,11 @@ internal object RtkCommandOptimizer {
             if [ -x "$RTK_BINARY" ]; then
                 _taixu_rtk_rewritten="${'$'}("$RTK_BINARY" rewrite $quotedCommand 2>/dev/null)"
                 _taixu_rtk_status=${'$'}?
-                if [ "${'$'}_taixu_rtk_status" -eq 0 ] && [ -n "${'$'}_taixu_rtk_rewritten" ]; then
+                case "${'$'}_taixu_rtk_rewritten" in
+                    "rtk "*) ;;
+                    *) _taixu_rtk_status=1 ;;
+                esac
+                if [ "${'$'}_taixu_rtk_status" -eq 0 ] && [ "${'$'}(printf '%s' "${'$'}_taixu_rtk_rewritten" | wc -l)" -eq 0 ]; then
                     eval "${'$'}_taixu_rtk_rewritten"
                 else
                     $command

--- a/harness/src/test/java/top/wkbin/taixu/harness/RtkCommandOptimizerTest.kt
+++ b/harness/src/test/java/top/wkbin/taixu/harness/RtkCommandOptimizerTest.kt
@@ -33,10 +33,66 @@ class RtkCommandOptimizerTest {
     }
 
     @Test
-    fun `single quoted arguments are preserved for rewrite`() {
-        val prepared = RtkCommandOptimizer.prepare("git log --format='%h %s'", enabled = true)
+    fun `quoted glob arguments are optimized and passed through verbatim`() {
+        val command = "rg -n 'fun ' --glob '*.kt' ."
+        val prepared = RtkCommandOptimizer.prepare(command, enabled = true)
 
-        assertTrue(prepared.commandLine.contains("rewrite 'git log --format='\"'\"'%h %s'\"'\"''"))
-        assertFalse(prepared.commandLine.contains("\\\\\""))
+        // 通配符不再阻止改写：rewrite 输出保留原引号，eval 只做一次展开。
+        assertTrue(prepared.commandLine.contains("rewrite 'rg -n '\"'\"'fun '\"'\"' --glob '\"'\"'*.kt'\"'\"' .'"))
+        assertTrue(prepared.commandLine.contains("else\n        $command"))
+    }
+
+    @Test
+    fun `find with a quoted name pattern is optimized`() {
+        val command = "find . -name '*.kt'"
+        val prepared = RtkCommandOptimizer.prepare(command, enabled = true)
+
+        assertTrue(prepared.commandLine.contains("rewrite 'find . -name '\"'\"'*.kt'\"'\"''"))
+    }
+
+    @Test
+    fun `long listing keeps using RTK because -l is not a machine readable flag for ls`() {
+        val prepared = RtkCommandOptimizer.prepare("ls -la src", enabled = true)
+
+        assertTrue(prepared.commandLine.contains("rewrite 'ls -la src'"))
+    }
+
+    @Test
+    fun `machine readable output is never rewritten`() {
+        val untouched = listOf(
+            "git status --porcelain",
+            "git log --pretty=oneline",
+            "git diff --numstat",
+            "grep -l TODO src",
+            "grep -rnl TODO src",
+            "rg --files-with-matches TODO",
+            "rg -c TODO",
+            "rg -q TODO",
+            "find . -name '*.kt' -print0",
+            "find . -name '*.kt' -exec rm {} +",
+            "ls -1",
+            "ls -la1",
+        )
+
+        untouched.forEach { command ->
+            assertEquals(command, RtkCommandOptimizer.prepare(command, enabled = true).commandLine)
+        }
+    }
+
+    @Test
+    fun `commands without an rtk equivalent stay raw`() {
+        // wc 会丢掉单文件路径并把总计行改写成 Σ；du/yarn/bun/mvnw 在 RTK 里没有子命令。
+        listOf("wc -l build.gradle.kts", "du -sh build", "yarn test", "bun install", "./mvnw verify").forEach { command ->
+            assertEquals(command, RtkCommandOptimizer.prepare(command, enabled = true).commandLine)
+        }
+    }
+
+    @Test
+    fun `only a single line rtk rewrite is evaluated`() {
+        val prepared = RtkCommandOptimizer.prepare("ls -la", enabled = true)
+
+        // 只有以 "rtk " 开头的单行输出才会进入 eval，避免未来版本把诊断文本写到 stdout。
+        assertTrue(prepared.commandLine.contains("\"rtk \"*) ;;"))
+        assertTrue(prepared.commandLine.contains("wc -l)\" -eq 0 ]"))
     }
 }

--- a/runtime/browser/src/main/java/top/wkbin/taixu/runtime/browser/engine/AndroidInAppBrowserEngine.kt
+++ b/runtime/browser/src/main/java/top/wkbin/taixu/runtime/browser/engine/AndroidInAppBrowserEngine.kt
@@ -273,6 +273,8 @@ class AndroidInAppBrowserEngine(
         val tabIds = pool.list().map { it.tabId }
         pool.shutdown()
         tabIds.forEach { screenshotRecorder.cleanup(it) }
+        // 截图线程由 recorder 自己持有：不在这里 quit 就会随每次引擎重建各留一个常驻线程。
+        screenshotRecorder.shutdown()
     }
 
     // ===== 注入式 Hook 引擎（阶段 1）=====

--- a/runtime/browser/src/main/java/top/wkbin/taixu/runtime/browser/screenshot/ScreenshotRecorder.kt
+++ b/runtime/browser/src/main/java/top/wkbin/taixu/runtime/browser/screenshot/ScreenshotRecorder.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -35,7 +36,19 @@ import kotlin.time.Duration.Companion.milliseconds
  */
 class ScreenshotRecorder(private val context: Context) {
 
-    private val ioThread by lazy { HandlerThread("taixu-browser-screenshot").apply { start() } }
+    /**
+     * 资源归属：本类创建 HandlerThread，就必须自己 quit —— 引擎每次注销重建都会 new 一个
+     * Recorder（[top.wkbin.taixu.runtime.browser.BrowserRegistryImpl.shutdown] 会清空引擎列表），
+     * 不回收就是一轮一个常驻线程。用显式 [Lazy] 而不是 `by lazy` 是为了让 [shutdown]
+     * 能区分“线程真的起过”和“从未截图”，后者不该被 shutdown 反向唤起。
+     */
+    private val ioThreadDelegate = lazy {
+        HandlerThread("taixu-browser-screenshot").apply {
+            isDaemon = true
+            start()
+        }
+    }
+    private val ioThread by ioThreadDelegate
     private val ioHandler by lazy { Handler(ioThread.looper) }
     private val mainHandler = Handler(Looper.getMainLooper())
 
@@ -82,7 +95,7 @@ class ScreenshotRecorder(private val context: Context) {
             lateRecycleScope.launch { deferred.await()?.recycle() }
             return null
         }
-        val file = writePngAsync(tabId, bmp)
+        val file = writePngAsync(tabId, bmp) ?: return null
         return ToolImageRef(
             id = UUID.randomUUID().toString(),
             uri = file,
@@ -93,12 +106,14 @@ class ScreenshotRecorder(private val context: Context) {
         )
     }
 
-    private suspend fun writePngAsync(tabId: String, bmp: Bitmap): String {
+    private suspend fun writePngAsync(tabId: String, bmp: Bitmap): String? {
         val dir = File(context.cacheDir, "taixu-browser/screenshots/$tabId").apply { mkdirs() }
         val filename = SimpleDateFormat("yyyyMMdd_HHmmss_SSS", Locale.US).format(Date()) + ".png"
         val file = File(dir, filename)
         val done = CompletableDeferred<String>()
-        ioHandler.post {
+        // shutdown 之后 looper 已退出，post 返回 false：必须在这里回收并放弃，
+        // 否则 done 永远不会完成，调用方协程会永久挂起。
+        val posted = ioHandler.post {
             runCatching {
                 FileOutputStream(file).use { out ->
                     bmp.compress(Bitmap.CompressFormat.PNG, 90, out)
@@ -106,6 +121,10 @@ class ScreenshotRecorder(private val context: Context) {
             }
             bmp.recycle()
             done.complete(file.absolutePath)
+        }
+        if (!posted) {
+            bmp.recycle()
+            return null
         }
         // 挂起等待压缩完成：不再 runBlocking 阻塞 MCP 工作线程，也保留取消传播
         return done.await()
@@ -117,5 +136,18 @@ class ScreenshotRecorder(private val context: Context) {
             val dir = File(context.cacheDir, "taixu-browser/screenshots/$tabId")
             if (dir.exists()) dir.deleteRecursively()
         }
+    }
+
+    /**
+     * 释放本类持有的线程与协程作用域。引擎 shutdown 时调用；未截过图时不会唤起 lazy 线程。
+     *
+     * 正在进行的压缩会被 [HandlerThread.quitSafely] 保留到执行完（已入队的消息照常处理），
+     * 之后再 post 会被拒绝并由 [writePngAsync] 回收 Bitmap。
+     */
+    fun shutdown() {
+        if (ioThreadDelegate.isInitialized()) {
+            ioThread.quitSafely()
+        }
+        lateRecycleScope.cancel()
     }
 }

--- a/runtime/src/main/java/top/wkbin/taixu/runtime/webchat/AndroidHttpServer.kt
+++ b/runtime/src/main/java/top/wkbin/taixu/runtime/webchat/AndroidHttpServer.kt
@@ -3,6 +3,7 @@ package top.wkbin.taixu.runtime.webchat
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.io.OutputStream
 import java.net.InetSocketAddress
@@ -11,7 +12,12 @@ import java.net.Socket
 import java.net.SocketException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
-import java.util.concurrent.Executors
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Small HTTP/1.1 server backed only by Android-supported java.net APIs.
@@ -19,18 +25,38 @@ import java.util.concurrent.Executors
  * Android does not ship the desktop-JDK `com.sun.net.httpserver` module. This
  * adapter intentionally exposes only the subset WebChat needs: prefix routes,
  * fixed-length responses, and an open-ended response body for SSE.
+ *
+ * 资源归属：ServerSocket、缺省线程池与所有已 accept 的连接都由本类持有，
+ * [stop] 必须把它们全部释放 —— 手机上服务会被反复启停，任何一项残留都会
+ * 累积成常驻线程或悬挂的文件描述符。外部注入的线程池归注入方所有，不在此关闭。
  */
 internal class AndroidHttpServer private constructor(
     private val address: InetSocketAddress,
     private val backlog: Int,
 ) {
     private val contexts = ConcurrentHashMap<String, AndroidHttpHandler>()
+
+    /** 已 accept 且尚未关闭的连接，用于 [stop] 时回收 SSE 这类长连接。 */
+    private val activeSockets = ConcurrentHashMap.newKeySet<Socket>()
     private var serverSocket: ServerSocket? = null
 
     @Volatile
     private var running = false
 
-    var executor: Executor = Executors.newCachedThreadPool()
+    private var externalExecutor: Executor? = null
+    private var ownedExecutor: ExecutorService? = null
+
+    /**
+     * 工作线程池。默认由本类懒创建并在 [stop] 中回收；一旦外部注入，
+     * 关闭责任随之转移给注入方（本类只会释放自己创建的那个）。
+     */
+    var executor: Executor
+        get() = currentExecutor()
+        set(value) = synchronized(this) {
+            ownedExecutor?.shutdownNow()
+            ownedExecutor = null
+            externalExecutor = value
+        }
 
     fun createContext(path: String, handler: AndroidHttpHandler) {
         require(path.startsWith('/')) { "HTTP context path must start with /" }
@@ -57,17 +83,51 @@ internal class AndroidHttpServer private constructor(
         running = false
         runCatching { serverSocket?.close() }
         serverSocket = null
+        // 已 accept 的连接不会随监听 socket 一起关闭：SSE 流可以挂住工作线程与 fd。
+        activeSockets.forEach { runCatching { it.close() } }
+        activeSockets.clear()
+        ownedExecutor?.shutdownNow()
+        ownedExecutor = null
         if (delaySeconds > 0) {
             // The WebChat caller always requests an immediate stop. The argument
             // is kept to mirror the old API and make that intent explicit.
         }
     }
 
+    private fun currentExecutor(): Executor = synchronized(this) {
+        externalExecutor
+            ?: ownedExecutor?.takeIf { !it.isShutdown }
+            ?: createOwnedExecutor().also { ownedExecutor = it }
+    }
+
+    /**
+     * 缺省线程池：并发上限与旧的 `newFixedThreadPool(8)` 一致，但核心线程允许超时回收
+     * 且全部为 daemon —— 服务停止后不留常驻线程，也不会阻止进程退出。
+     */
+    private fun createOwnedExecutor(): ExecutorService = ThreadPoolExecutor(
+        MAX_WORKER_THREADS,
+        MAX_WORKER_THREADS,
+        WORKER_KEEP_ALIVE_SECONDS,
+        TimeUnit.SECONDS,
+        LinkedBlockingQueue(),
+    ) { runnable -> Thread(runnable, "taixu-webchat-worker").apply { isDaemon = true } }
+        .apply { allowCoreThreadTimeOut(true) }
+
     private fun acceptConnections(socket: ServerSocket) {
         while (running) {
             try {
                 val client = socket.accept()
-                executor.execute { handleClient(client) }
+                if (!running) {
+                    runCatching { client.close() }
+                    break
+                }
+                activeSockets.add(client)
+                try {
+                    currentExecutor().execute { handleClient(client) }
+                } catch (_: RejectedExecutionException) {
+                    activeSockets.remove(client)
+                    runCatching { client.close() }
+                }
             } catch (_: SocketException) {
                 if (running) continue
                 break
@@ -140,10 +200,15 @@ internal class AndroidHttpServer private constructor(
                 requestURI = AndroidHttpUri(path, query),
                 requestHeaders = headers,
                 requestBody = ByteArrayInputStream(body, 0, offset),
+                // 异步 handler 在协程里晚于本方法关闭连接，靠回调而不是轮询摘除。
+                onClose = { activeSockets.remove(socket) },
             )
             handler.handle(exchange)
         } catch (_: Exception) {
             runCatching { socket.close() }
+        } finally {
+            // 覆盖未走到 exchange 的早退路径（400/404/431/413 与读取异常）。
+            if (socket.isClosed) activeSockets.remove(socket)
         }
     }
 
@@ -160,16 +225,22 @@ internal class AndroidHttpServer private constructor(
         runCatching { socket.close() }
     }
 
+    /**
+     * 逐字节读取一行。使用 [ByteArrayOutputStream] 而不是 `ArrayList<Byte>`：
+     * 后者会为每个请求头字节分配一个装箱引用槽，8 KB 的行头即 8 K 个引用。
+     */
     private fun readHttpLine(input: InputStream): String? {
-        val bytes = ArrayList<Byte>(128)
-        while (bytes.size <= MAX_LINE_BYTES) {
+        val buffer = ByteArrayOutputStream(INITIAL_LINE_BYTES)
+        while (buffer.size() <= MAX_LINE_BYTES) {
             val value = input.read()
-            if (value < 0) return if (bytes.isEmpty()) null else bytes.toByteArray().toString(Charsets.US_ASCII)
+            if (value < 0) {
+                return if (buffer.size() == 0) null else buffer.toString(Charsets.US_ASCII.name())
+            }
             if (value == '\n'.code) break
-            if (value != '\r'.code) bytes.add(value.toByte())
+            if (value != '\r'.code) buffer.write(value)
         }
-        if (bytes.size > MAX_LINE_BYTES) throw IllegalArgumentException("HTTP line too long")
-        return bytes.toByteArray().toString(Charsets.US_ASCII)
+        if (buffer.size() > MAX_LINE_BYTES) throw IllegalArgumentException("HTTP line too long")
+        return buffer.toString(Charsets.US_ASCII.name())
     }
 
     companion object {
@@ -178,6 +249,9 @@ internal class AndroidHttpServer private constructor(
         private const val MAX_LINE_BYTES = 8 * 1024
         private const val MAX_HEADER_BYTES = 32 * 1024
         private const val MAX_BODY_BYTES = 2 * 1024 * 1024
+        private const val INITIAL_LINE_BYTES = 128
+        private const val MAX_WORKER_THREADS = 8
+        private const val WORKER_KEEP_ALIVE_SECONDS = 30L
 
         fun create(address: InetSocketAddress, backlog: Int): AndroidHttpServer =
             AndroidHttpServer(address, backlog)
@@ -217,6 +291,7 @@ internal class AndroidHttpExchange(
     val requestURI: AndroidHttpUri,
     val requestHeaders: AndroidHttpHeaders,
     val requestBody: InputStream,
+    private val onClose: () -> Unit = {},
 ) {
     val responseHeaders = AndroidHttpHeaders()
     private val output = BufferedOutputStream(socket.getOutputStream())
@@ -224,6 +299,11 @@ internal class AndroidHttpExchange(
 
     @Volatile
     private var responseStarted = false
+    private val closed = AtomicBoolean(false)
+
+    /** 响应是否已经开始：异常兜底路径据此决定还能不能再写一个错误响应。 */
+    val isResponseStarted: Boolean
+        get() = responseStarted
 
     @Synchronized
     fun sendResponseHeaders(code: Int, responseLength: Long) {
@@ -243,9 +323,11 @@ internal class AndroidHttpExchange(
         output.flush()
     }
 
+    /** 幂等：重复调用只会触发一次 [onClose]，SSE 广播失败与协程兜底可以放心各调一次。 */
     fun close() {
         runCatching { output.close() }
         runCatching { socket.close() }
+        if (closed.compareAndSet(false, true)) runCatching { onClose() }
     }
 
     private fun statusText(code: Int): String = when (code) {

--- a/runtime/src/main/java/top/wkbin/taixu/runtime/webchat/WebChatBridgeServer.kt
+++ b/runtime/src/main/java/top/wkbin/taixu/runtime/webchat/WebChatBridgeServer.kt
@@ -9,9 +9,9 @@ import java.net.InetSocketAddress
 import java.net.NetworkInterface
 import java.net.URLDecoder
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.Executors
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -71,7 +71,6 @@ class WebChatBridgeServer @Inject constructor(
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var httpServer: AndroidHttpServer? = null
-    private val executor = Executors.newFixedThreadPool(8)
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true; explicitNulls = false }
     private val _status = MutableStateFlow(WebChatServerStatus())
     val status: StateFlow<WebChatServerStatus> = _status.asStateFlow()
@@ -87,7 +86,9 @@ class WebChatBridgeServer @Inject constructor(
         if (_status.value.isRunning) return true
         return try {
             val generatedPin = pin ?: generatePin()
-            val server = AndroidHttpServer.create(InetSocketAddress(port), 0).also { it.executor = executor }
+            // 工作线程池由 AndroidHttpServer 自己持有：stop() 时随服务一起回收，
+            // 不再让本类持有一个永不 shutdown 的 fixedThreadPool。
+            val server = AndroidHttpServer.create(InetSocketAddress(port), 0)
             server.createContext("/webchat/api/session/bootstrap", SessionBootstrapHandler())
             server.createContext("/webchat/api/bootstrap", BootstrapHandler())
             server.createContext("/webchat/api/conversations", ConversationsHandler())
@@ -152,6 +153,34 @@ class WebChatBridgeServer @Inject constructor(
         _status.value = _status.value.copy(activeConnections = sseEmitters.size)
     }
 
+    /**
+     * 请求协程的统一兜底。handler 在 [scope] 里异步执行，抛出的异常不会回到
+     * [AndroidHttpServer] 的 accept 循环，socket 会连同工作线程一起挂住：
+     * 这里保证异常路径也回一个 500 并最终关闭连接（[AndroidHttpExchange.close] 幂等）。
+     *
+     * 返回 Unit 而不是 Job：调用点是 `override fun handle(...) = launchRequest(...) { }`，
+     * 返回 Job 会迫使每个 handler 末尾补一个 `.let { }` 才能满足 Unit 覆写。
+     */
+    private fun launchRequest(
+        exchange: AndroidHttpExchange,
+        block: suspend CoroutineScope.() -> Unit,
+    ) {
+        scope.launch {
+            try {
+                block()
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (throwable: Throwable) {
+                logger.e("太墟智枢 Web 请求处理失败：${exchange.requestURI.path}", throwable)
+                if (!exchange.isResponseStarted) {
+                    runCatching { sendJson(exchange, 500, errorJson(throwable.message ?: "请求处理失败")) }
+                }
+            } finally {
+                runCatching { exchange.close() }
+            }
+        }
+    }
+
     private inner class StaticAssetHandler : AndroidHttpHandler {
         override fun handle(exchange: AndroidHttpExchange) {
             val path = exchange.requestURI.path.removePrefix("/").trimStart('/')
@@ -168,18 +197,18 @@ class WebChatBridgeServer @Inject constructor(
     }
 
     private inner class SessionBootstrapHandler : AndroidHttpHandler {
-        override fun handle(exchange: AndroidHttpExchange) = scope.launch {
-            if (handlePreflight(exchange)) return@launch
+        override fun handle(exchange: AndroidHttpExchange) = launchRequest(exchange) {
+            if (handlePreflight(exchange)) return@launchRequest
             val token = requestJson(exchange)["token"]?.jsonPrimitive?.content.orEmpty()
             if (token != _status.value.pinCode) sendJson(exchange, 401, errorJson("配对码不正确"))
             else sendJson(exchange, 200, buildJsonObject { put("authenticated", true) })
-        }.let { }
+        }
     }
 
     private inner class BootstrapHandler : AndroidHttpHandler {
-        override fun handle(exchange: AndroidHttpExchange) = scope.launch {
-            if (handlePreflight(exchange)) return@launch
-            if (!requireAuthenticated(exchange)) return@launch
+        override fun handle(exchange: AndroidHttpExchange) = launchRequest(exchange) {
+            if (handlePreflight(exchange)) return@launchRequest
+            if (!requireAuthenticated(exchange)) return@launchRequest
             val configuredModels = models.observeAll().firstValue()
             // 与 ChatViewModel 一致先播种内置短语，避免聊天页从未打开时列表为空
             runCatching { quickPhrases.ensureInitialized() }
@@ -217,13 +246,13 @@ class WebChatBridgeServer @Inject constructor(
                     put("root", buildJsonObject { put("path", "/workspace") })
                 })
             })
-        }.let { }
+        }
     }
 
     private inner class ConversationsHandler : AndroidHttpHandler {
-        override fun handle(exchange: AndroidHttpExchange) = scope.launch {
-            if (handlePreflight(exchange)) return@launch
-            if (!requireAuthenticated(exchange)) return@launch
+        override fun handle(exchange: AndroidHttpExchange) = launchRequest(exchange) {
+            if (handlePreflight(exchange)) return@launchRequest
+            if (!requireAuthenticated(exchange)) return@launchRequest
             try {
                 val suffix = exchange.requestURI.path.substringAfter("/conversations", "").trim('/')
                 val parts = suffix.split('/').filter(String::isNotBlank)
@@ -283,7 +312,7 @@ class WebChatBridgeServer @Inject constructor(
             } catch (throwable: Throwable) {
                 sendJson(exchange, 400, errorJson(throwable.message ?: "会话操作失败"))
             }
-        }.let { }
+        }
     }
 
     private suspend fun startRun(exchange: AndroidHttpExchange, sessionId: String) {
@@ -336,9 +365,9 @@ class WebChatBridgeServer @Inject constructor(
     }
 
     private inner class TasksHandler : AndroidHttpHandler {
-        override fun handle(exchange: AndroidHttpExchange) = scope.launch {
-            if (handlePreflight(exchange)) return@launch
-            if (!requireAuthenticated(exchange)) return@launch
+        override fun handle(exchange: AndroidHttpExchange) = launchRequest(exchange) {
+            if (handlePreflight(exchange)) return@launchRequest
+            if (!requireAuthenticated(exchange)) return@launchRequest
             val suffix = exchange.requestURI.path.substringAfter("/tasks", "").trim('/')
             val parts = suffix.split('/').filter(String::isNotBlank)
             if (parts.size == 2 && parts[1] == "cancel" && exchange.requestMethod == "POST") {
@@ -349,7 +378,7 @@ class WebChatBridgeServer @Inject constructor(
             } else {
                 sendText(exchange, 404, "任务接口不存在")
             }
-        }.let { }
+        }
     }
 
     private inner class SseEventsHandler : AndroidHttpHandler {
@@ -371,9 +400,9 @@ class WebChatBridgeServer @Inject constructor(
     }
 
     private inner class WorkspacesHandler : AndroidHttpHandler {
-        override fun handle(exchange: AndroidHttpExchange) = scope.launch {
-            if (handlePreflight(exchange)) return@launch
-            if (!requireAuthenticated(exchange)) return@launch
+        override fun handle(exchange: AndroidHttpExchange) = launchRequest(exchange) {
+            if (handlePreflight(exchange)) return@launchRequest
+            if (!requireAuthenticated(exchange)) return@launchRequest
             try {
                 val suffix = exchange.requestURI.path.substringAfter("/workspaces", "").trim('/')
                 when {
@@ -386,7 +415,7 @@ class WebChatBridgeServer @Inject constructor(
             } catch (throwable: Throwable) {
                 sendJson(exchange, 400, errorJson(throwable.message ?: "工作区操作失败"))
             }
-        }.let { }
+        }
     }
 
     private suspend fun listWorkspace(exchange: AndroidHttpExchange) {

--- a/runtime/src/test/java/top/wkbin/taixu/runtime/webchat/AndroidHttpServerTest.kt
+++ b/runtime/src/test/java/top/wkbin/taixu/runtime/webchat/AndroidHttpServerTest.kt
@@ -3,6 +3,11 @@ package top.wkbin.taixu.runtime.webchat
 import java.net.InetSocketAddress
 import java.net.ServerSocket
 import java.net.Socket
+import java.net.SocketTimeoutException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -35,6 +40,103 @@ class AndroidHttpServerTest {
             assertTrue(response.contains("Content-Length: 11"))
             assertTrue(response.endsWith("{\"ok\":true}"))
         } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `stop closes open ended connections and releases the listening socket`() {
+        val port = ServerSocket(0).use { it.localPort }
+        val server = AndroidHttpServer.create(InetSocketAddress("127.0.0.1", port), 0)
+        val streaming = CountDownLatch(1)
+        server.createContext("/api/events") { exchange ->
+            exchange.responseHeaders.add("Content-Type", "text/event-stream")
+            exchange.sendResponseHeaders(200, 0)
+            exchange.responseBody.write("event: ping\ndata: {}\n\n".toByteArray())
+            exchange.responseBody.flush()
+            streaming.countDown()
+            // 故意不关闭：模拟 WebChat 的 SSE 长连接，回收责任落在 stop() 上。
+        }
+
+        val client = Socket()
+        try {
+            server.start()
+            client.connect(InetSocketAddress("127.0.0.1", port), 5_000)
+            client.soTimeout = 5_000
+            client.getOutputStream().apply {
+                write("GET /api/events HTTP/1.1\r\nHost: localhost\r\n\r\n".toByteArray())
+                flush()
+            }
+            val input = client.getInputStream()
+            assertTrue("SSE 首字节应可读", input.read() >= 0)
+            assertTrue("handler 应已接管连接", streaming.await(5, TimeUnit.SECONDS))
+
+            server.stop(0)
+
+            // 连接被服务端关闭时读到 EOF 或 RST；若仍挂着，soTimeout 会抛超时 —— 那就是泄漏。
+            val outcome = runCatching {
+                var value = input.read()
+                while (value >= 0) value = input.read()
+            }
+            assertFalse(
+                "stop() 必须关闭已 accept 的长连接",
+                outcome.exceptionOrNull() is SocketTimeoutException,
+            )
+
+            // 监听 socket 已释放：同一端口可以立刻重新绑定。
+            ServerSocket().use { probe ->
+                probe.reuseAddress = true
+                probe.bind(InetSocketAddress("127.0.0.1", port))
+            }
+        } finally {
+            runCatching { client.close() }
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `server can be restarted after stop`() {
+        val port = ServerSocket(0).use { it.localPort }
+        val server = AndroidHttpServer.create(InetSocketAddress("127.0.0.1", port), 0)
+        server.createContext("/api/ping") { exchange ->
+            val body = "pong".toByteArray()
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.write(body)
+            exchange.close()
+        }
+
+        try {
+            repeat(2) {
+                server.start()
+                val response = Socket("127.0.0.1", port).use { socket ->
+                    socket.soTimeout = 5_000
+                    socket.getOutputStream().apply {
+                        write("GET /api/ping HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n".toByteArray())
+                        flush()
+                    }
+                    socket.getInputStream().bufferedReader().readText()
+                }
+                assertTrue("第 ${it + 1} 次启动应正常响应", response.endsWith("pong"))
+                server.stop(0)
+            }
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `injected executor is owned by the caller and survives stop`() {
+        val port = ServerSocket(0).use { it.localPort }
+        val server = AndroidHttpServer.create(InetSocketAddress("127.0.0.1", port), 0)
+        val injected = Executors.newSingleThreadExecutor()
+        server.executor = injected
+
+        try {
+            server.start()
+            server.stop(0)
+            assertFalse("外部注入的线程池不应被 stop() 关闭", injected.isShutdown)
+        } finally {
+            injected.shutdownNow()
             server.stop(0)
         }
     }


### PR DESCRIPTION
分支：`fix/resource-lifecycle-and-rtk-output-guards`（基于 `main` @ 2661f9a）
提交：3 个，改动 7 个文件，+415 / −53

## 背景

两类问题，共同点是"资源与语义的所有权没有闭环"：

1. **资源泄漏**：创建者不释放。`WebChatBridgeServer` 建了线程池不 shutdown，
   `AndroidHttpServer.stop()` 只关监听 socket 不关已 accept 的连接，
   `ScreenshotRecorder` 建了 HandlerThread 没有任何回收入口。
2. **RTK 改写越界**：`RtkCommandOptimizer` 按可执行文件名一刀切放行，
   把本该被下游解析的输出（`grep -l`、`git --porcelain`、`find -print0`）也压缩掉了。

## 1. fix(webchat)：回收线程池、长连接与异常请求协程

| 位置 | 原状 | 现状 |
| --- | --- | --- |
| `WebChatBridgeServer.executor` | `Executors.newFixedThreadPool(8)` 从不 shutdown，每次启停留 8 个常驻非 daemon 线程 | 池归 `AndroidHttpServer` 持有：懒创建、`stop()` 时 `shutdownNow`、daemon + 核心线程超时回收 |
| `AndroidHttpServer.stop()` | 只 `serverSocket.close()`，已 accept 的连接与 SSE 长连接连 fd 一起悬挂 | `activeSockets` 登记全部连接，`stop()` 逐个关闭 |
| `AndroidHttpExchange.close()` | 无回收通知 | 新增 `onClose` 回调 + 幂等保护，连接关闭即从 `activeSockets` 精确摘除 |
| 异步 handler | `scope.launch` 内抛异常无人接：socket 与工作线程一起挂住 | `launchRequest` 统一兜底：未开始响应则回 500，`finally` 必关连接 |
| `readHttpLine` | `ArrayList<Byte>` 逐字节装箱，8 KB 行头 = 8 K 个装箱引用 | `ByteArrayOutputStream` |

注入的线程池仍归注入方所有（`stop()` 不会关它），避免把外部生命周期悄悄接管过来。

## 2. fix(browser)：补齐 ScreenshotRecorder 回收链路

`BrowserRegistryImpl.shutdown()` 会 `inAppEngine.clear()`，下次 bootstrap 会重新
`new AndroidInAppBrowserEngine` → `new ScreenshotRecorder`，而 Recorder 的
HandlerThread 与 `lateRecycleScope` 没有任何释放入口：每轮引擎重建留下一个常驻线程。

- 新增 `ScreenshotRecorder.shutdown()`：`quitSafely()` + `lateRecycleScope.cancel()`，
  由 `AndroidInAppBrowserEngine.shutdown()` 调用。
- HandlerThread 改 daemon；用显式 `Lazy` 保证"从未截图"时 `shutdown()` 不会反向把线程唤起。
- `writePngAsync` 检查 `Handler.post` 返回值：looper 已退出时回收 Bitmap 并返回 null，
  否则 `CompletableDeferred` 永不完成，调用方协程会永久挂起。

## 3. fix(harness)：RTK 改写的机器可读输出护栏

压缩的收益是给模型看的输出更短；代价是一旦改写了要被解析的输出，后续步骤会**静默**拿到错的文本。

- 新增按命令区分的机器可读标志表，命中即原样执行。必须按命令区分，不能全局匹配：
  `ls -l` 是压缩收益最高的形态，`grep -l` 却只输出文件名列表。
  - `grep`/`rg`：`-q -c -l -L -o --vimgrep`（含 `-rnl` 这类短选项聚类）
  - `git`：`--porcelain --numstat --name-only --name-status --format --pretty --raw`
  - `find`：`-print0 -printf -exec -execdir -ok -okdir -fprint`
  - `ls`：`-1`；通用：`--json -z --null --print0`
- 白名单剔除 `wc`（单文件调用会丢文件名、总计行被改成 `Σ`）与 `du`/`yarn`/`bun`/`mvnw`
  （RTK 无对应子命令，改写注定回退，白付两次进程启动），补上 `mvnd`。
- 放行通配符与花括号：`rtk rewrite` 输出保留原引号，`eval` 只做一次展开，与直接执行等价。
  于是最常用、收益也最高的 `find . -name '*.kt'`、`rg -n x --glob '*.kt'` 也能压缩。
- `eval` 前双重校验：只接受**以 `rtk ` 开头的单行**输出，未来版本把诊断信息写进 stdout 时自动回退原命令。

## 验证

沙箱是 aarch64 Android + PRoot，跑不动 AGP 9.3.1 全量构建，改用 `kotlin-compiler-embeddable`
2.4.10（与 `libs.versions.toml` 的 `kotlin` 版本一致）独立编译 + JUnit 4.13.2 直跑：

| 目标 | 方式 | 结果 |
| --- | --- | --- |
| `RtkCommandOptimizer` + 测试 | 独立编译 + 运行 | 9 / 9 通过 |
| `AndroidHttpServer` + 测试 | 独立编译 + 运行（真实 socket） | 4 / 4 通过 |
| `WebChatBridgeServer` 的 `launchRequest` 结构 | 结构探针（真实 `AndroidHttpServer` + socket，3 条路径：200 / 异常前回 500 / 异常后不重复响应头） | 3 / 3 通过 |
| `ScreenshotRecorder` | `android-34/android.jar` + coroutines 1.11.0 + 真实 `ToolImageRef` 编译 | 通过 |
| 测试有效性 | 变异测试：把 `stop()` 的回收逻辑与 `-l` 护栏改回旧行为 | 对应两个测试如期失败 |

新增测试 7 个（`AndroidHttpServerTest` 3 个、`RtkCommandOptimizerTest` 6 个中 4 个为新增场景）。

**未验证**：Gradle 全量 `assembleDebug` 与 instrumentation 测试（沙箱无法运行 AGP）。
`WebChatBridgeServer.kt` 因依赖 Hilt/Android Context 无法独立编译，其新增结构以等价探针在真实
socket 上验证，建议 CI 跑一次 `:runtime:test :harness:test` 复核。
