### PR TITLE
fix(harness): 约束上下文压缩触发线 + 5xx/图片400 降级

### DIFF
--- a/apk_verify/TaiXuDev-arm64-debug.apk.sha256
+++ b/apk_verify/TaiXuDev-arm64-debug.apk.sha256
@@ -1,0 +1,1 @@
+d63a67c456b7330cc4ad31743f9c3b40ec99d83e66811a53626a8ef96fb9a993  output/TaiXuDev-arm64-debug.apk

--- a/harness/src/main/java/top/wkbin/taixu/harness/AnthropicApi.kt
+++ b/harness/src/main/java/top/wkbin/taixu/harness/AnthropicApi.kt
@@ -53,6 +53,9 @@ internal class AnthropicApi(
                     if (response.code == 429) {
                         throw ProviderClient.rateLimitException(response.code, body, response.header("Retry-After"))
                     }
+                    if (response.code in 500..599) {
+                        throw ProviderClient.transientHttpException(response.code, body, response.header("Retry-After"))
+                    }
                     throw IllegalStateException("Claude 请求失败 HTTP ${response.code}：${extractError(body)}")
                 }
                 parseFinalResponse(body)
@@ -86,6 +89,9 @@ internal class AnthropicApi(
                     val errorBody = response.body.string()
                     if (response.code == 429) {
                         throw ProviderClient.rateLimitException(response.code, errorBody, response.header("Retry-After"))
+                    }
+                    if (response.code in 500..599) {
+                        throw ProviderClient.transientHttpException(response.code, errorBody, response.header("Retry-After"))
                     }
                     throw IllegalStateException("Claude 请求失败 HTTP ${response.code}：${extractError(errorBody)}")
                 }

--- a/harness/src/main/java/top/wkbin/taixu/harness/ContextWindowPolicy.kt
+++ b/harness/src/main/java/top/wkbin/taixu/harness/ContextWindowPolicy.kt
@@ -220,7 +220,10 @@ object ContextWindowPolicy {
                 is ToolCall -> estimateTokens(message.args.toString()) + estimateTokens(message.reasoning.orEmpty())
             }
             if (used + tokens > limit) {
-                val tokenBoundary = alignKeepFromIndex(messages, (index + 1).coerceIn(0, messages.lastIndex))
+                // 强制保留最近 2 条（即使某条自身超 limit），避免全折叠导致失忆
+                val candidate = (index + 1).coerceIn(0, messages.lastIndex)
+                    .coerceAtMost((messages.size - 2).coerceAtLeast(0))
+                val tokenBoundary = alignKeepFromIndex(messages, candidate)
                 return tokenBoundary
             }
             used += tokens

--- a/harness/src/main/java/top/wkbin/taixu/harness/ContextWindowPolicy.kt
+++ b/harness/src/main/java/top/wkbin/taixu/harness/ContextWindowPolicy.kt
@@ -13,6 +13,14 @@ object ContextWindowPolicy {
     private const val TOOL_SCHEMA_RESERVE_TOKENS = 4_096
     private const val MAX_SYSTEM_PROMPT_FRACTION = 0.60
     private const val MIN_SYSTEM_PROMPT_TOKENS = 512
+    /**
+     * 历史消息占用的绝对安全上限（token）。无论模型标称窗口多高，
+     * 压缩触发线都不超过此值，避免 flash 级模型在超高 token 下参数生成崩塌。
+     */
+    const val SAFE_GENERATION_CAP = 96_000
+    private const val MIN_HISTORY_TOKENS = 8_000
+    /** 预算上限：防止标称窗口过大导致系统提示词完全不截断。 */
+    const val MAX_CONTEXT_BUDGET = 200_000
     private const val APPROX_CHARS_PER_TOKEN = 4
 
     /**
@@ -193,8 +201,11 @@ object ContextWindowPolicy {
         if (budget <= 0) {
             return alignKeepFromIndex(messages, minimalKeepFromIndex(messages))
         }
-        val limit = (budget * INPUT_BUDGET_FRACTION).toInt() -
+        val rawLimit = (budget * INPUT_BUDGET_FRACTION).toInt() -
             systemTokens - RESERVED_OUTPUT_TOKENS - TOOL_SCHEMA_RESERVE_TOKENS
+        // 安全上限：标称窗口再大，历史也最多占 SAFE_GENERATION_CAP，
+        // 防止超大 contextTokens 把折叠触发线撑到永不生效。
+        val limit = minOf(rawLimit, SAFE_GENERATION_CAP).coerceAtLeast(MIN_HISTORY_TOKENS)
         if (limit <= 0) {
             return alignKeepFromIndex(messages, minimalKeepFromIndex(messages))
         }

--- a/harness/src/main/java/top/wkbin/taixu/harness/HarnessProviderRunner.kt
+++ b/harness/src/main/java/top/wkbin/taixu/harness/HarnessProviderRunner.kt
@@ -87,7 +87,8 @@ class HarnessProviderRunner @Inject constructor(
         // Context and prompt remain immutable during network retries. The configured model
         // window is authoritative: a transport heuristic must never persistently compact a
         // valid 128k/200k conversation down to 64k.
-        val requestMessages = assembleFor(model)
+        var requestMessages = assembleFor(model)
+        var imageStripped = false
         val estimatedRequestTokens = estimateTokens(requestMessages)
         val maxNetworkRetries = maxNetworkRetriesFor(estimatedRequestTokens, retryPolicy.maxRetries)
         val maxAttempts = maxNetworkRetries + 1
@@ -187,6 +188,23 @@ class HarnessProviderRunner @Inject constructor(
                 delay(retryPolicy.delayForRetry(netRetry).milliseconds)
             } catch (throwable: Throwable) {
                 stateMirrors.setThinkingLive(sessId, false)
+                // 模型不支持图片输入（HTTP 400）时，剥离全部图片降级重试一次，避免整轮中断
+                val lowerMsg = throwable.message.orEmpty().lowercase()
+                val pendingImages = requestMessages.sumOf { it.imageUrls.size }
+                if (!imageStripped && pendingImages > 0 &&
+                    ("do not support image" in lowerMsg || "image input" in lowerMsg || "supports image" in lowerMsg)
+                ) {
+                    imageStripped = true
+                    requestMessages = requestMessages.map { it.copy(imageUrls = emptyList()) }
+                    agentEventLogger.log(
+                        sessId, "VisionFallback",
+                        "模型不支持图片输入，已剥离 $pendingImages 张图片降级重试", throwable,
+                    )
+                    streamText.clear()
+                    streamReasoning.clear()
+                    messageProjector.remove(sessId, assistantId)
+                    continue
+                }
                 agentEventLogger.log(sessId, "ModelError", "LLM 调用失败: ${throwable.message}", throwable)
                 if (streamText.length > 0) {
                     persistAssistant(

--- a/harness/src/main/java/top/wkbin/taixu/harness/HarnessProviderRunner.kt
+++ b/harness/src/main/java/top/wkbin/taixu/harness/HarnessProviderRunner.kt
@@ -192,7 +192,11 @@ class HarnessProviderRunner @Inject constructor(
                 val lowerMsg = throwable.message.orEmpty().lowercase()
                 val pendingImages = requestMessages.sumOf { it.imageUrls.size }
                 if (!imageStripped && pendingImages > 0 &&
-                    ("do not support image" in lowerMsg || "image input" in lowerMsg || "supports image" in lowerMsg)
+                    ("do not support image" in lowerMsg || "does not support image" in lowerMsg ||
+                        "image input" in lowerMsg || "supports image" in lowerMsg ||
+                        "image not supported" in lowerMsg ||
+                        "不支持图片" in lowerMsg || "不支持图像" in lowerMsg ||
+                        "图片输入" in lowerMsg || "图像输入" in lowerMsg)
                 ) {
                     imageStripped = true
                     requestMessages = requestMessages.map { it.copy(imageUrls = emptyList()) }

--- a/harness/src/main/java/top/wkbin/taixu/harness/ProviderClient.kt
+++ b/harness/src/main/java/top/wkbin/taixu/harness/ProviderClient.kt
@@ -39,6 +39,13 @@ class LlmRateLimitException(
     val quotaExhausted: Boolean = false,
 ) : IOException(message)
 
+/** 上游临时故障（5xx，如 Cloudflare 524 origin timeout）：可退避重试，由网络重试路径统一处理。 */
+class TransientHttpException(
+    message: String,
+    val httpCode: Int,
+    val retryAfterSeconds: Long? = null,
+) : IOException(message)
+
 /** 可独立测试的 HTTP 层：OpenAI 兼容 chat/completions 请求与响应解析。 */
 internal class ChatApi(
     private val okHttpClient: OkHttpClient,
@@ -51,6 +58,9 @@ internal class ChatApi(
                 if (!response.isSuccessful) {
                     if (response.code == 429) {
                         throw ProviderClient.rateLimitException(response.code, body, response.header("Retry-After"))
+                    }
+                    if (response.code in 500..599) {
+                        throw ProviderClient.transientHttpException(response.code, body, response.header("Retry-After"))
                     }
                     throw IllegalStateException(ProviderClient.formatHttpErrorMessage(response.code, body))
                 }
@@ -137,6 +147,9 @@ internal class ChatApi(
                     val rawBody = response.body.string().take(512)
                     if (response.code == 429) {
                         throw ProviderClient.rateLimitException(response.code, rawBody, response.header("Retry-After"))
+                    }
+                    if (response.code in 500..599) {
+                        throw ProviderClient.transientHttpException(response.code, rawBody, response.header("Retry-After"))
                     }
                     throw IllegalStateException(ProviderClient.formatHttpErrorMessage(response.code, rawBody))
                 }
@@ -1038,6 +1051,13 @@ class ProviderClient @Inject constructor(
                         .toEpochSecond() - System.currentTimeMillis() / 1000L
                 }.getOrNull()?.takeIf { it > 0 }?.coerceAtMost(300L)
             return LlmRateLimitException(message, retrySeconds, quotaExhausted)
+        }
+
+        /** 5xx 上游临时故障（如 Cloudflare 524 origin timeout）：包装为可退避重试的 IOException。 */
+        internal fun transientHttpException(code: Int, rawBody: String, retryAfter: String?): TransientHttpException {
+            val message = formatHttpErrorMessage(code, rawBody)
+            val retrySeconds = retryAfter?.trim()?.toLongOrNull()?.coerceIn(1L, 300L)
+            return TransientHttpException(message, code, retrySeconds)
         }
 
         internal const val READ_TIMEOUT_MS = 5 * 60 * 1000L

--- a/harness/src/main/java/top/wkbin/taixu/harness/ResponsesApi.kt
+++ b/harness/src/main/java/top/wkbin/taixu/harness/ResponsesApi.kt
@@ -55,6 +55,9 @@ internal class ResponsesApi(
                     if (response.code == 429) {
                         throw ProviderClient.rateLimitException(response.code, body, response.header("Retry-After"))
                     }
+                    if (response.code in 500..599) {
+                        throw ProviderClient.transientHttpException(response.code, body, response.header("Retry-After"))
+                    }
                     throw IllegalStateException("Responses 请求失败 HTTP ${response.code}：${extractError(body)}")
                 }
                 parseFinalResponse(body)
@@ -88,6 +91,9 @@ internal class ResponsesApi(
                     val rawBody = response.body.string().take(512)
                     if (response.code == 429) {
                         throw ProviderClient.rateLimitException(response.code, rawBody, response.header("Retry-After"))
+                    }
+                    if (response.code in 500..599) {
+                        throw ProviderClient.transientHttpException(response.code, rawBody, response.header("Retry-After"))
                     }
                     throw IllegalStateException("Responses 请求失败 HTTP ${response.code}：${extractError(rawBody)}")
                 }

--- a/harness/src/main/java/top/wkbin/taixu/harness/compaction/CompactionManager.kt
+++ b/harness/src/main/java/top/wkbin/taixu/harness/compaction/CompactionManager.kt
@@ -1,5 +1,6 @@
 package top.wkbin.taixu.harness.compaction
 
+import android.util.Log
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -94,6 +95,11 @@ class CompactionManager @Inject constructor(
             payloadJson = json.encodeToString(CompactionPayload.serializer(), payload),
         )
         repository.appendToLane(sessionId, laneName, entry)
+        Log.d(
+            "ContextCompaction",
+            "压缩会话 $sessionId：折叠 ${collapsed.size} 条（累计 ${payload.cumulativeCompactedMessageCount}），" +
+                "保留 ${retained.size} 条，摘要 ${summary?.length ?: 0} 字符，压缩前估算 ${payload.estimatedTokensBefore} tokens",
+        )
         return CompactedContext(summary, retained)
     }
 

--- a/harness/src/main/java/top/wkbin/taixu/harness/session/ApiContextAssembler.kt
+++ b/harness/src/main/java/top/wkbin/taixu/harness/session/ApiContextAssembler.kt
@@ -42,8 +42,9 @@ class ApiContextAssembler @Inject constructor(
         thinkingMode: Boolean = false,
     ): List<ApiMessage> {
         val compactionEnabled = runCatching { settingsDataStore.contextCompactionEnabled.first() }.getOrDefault(true)
-        val budgetTokens = model.contextTokens
-            ?: runCatching { settingsDataStore.contextBudgetTokens.first() }.getOrDefault(128_000)
+        val budgetTokens = (model.contextTokens
+            ?: runCatching { settingsDataStore.contextBudgetTokens.first() }.getOrDefault(128_000))
+            .coerceIn(0, ContextWindowPolicy.MAX_CONTEXT_BUDGET)
         val toolCallMode = if (model.pureChatMode) ToolCallMode.DISABLED else model.toolCallMode
 
         var compactedContext = compactionManager.project(sessId)


### PR DESCRIPTION
## Summary
修复自定义迭代中 Agent 上下文**永不压缩**的根因（长会话 token 单调膨胀 67k→219k→146k，导致模型参数生成崩塌：参数夹带 `\/`、`[...omitted...]`、截断 JSON 括号），并顺带加固 provider 层健壮性（5xx 重试 / 图片 400 降级）。

## Changes
**方案 A · 治本（上下文压缩）**
- `ContextWindowPolicy`：新增 `SAFE_GENERATION_CAP=96k` 与 `MAX_CONTEXT_BUDGET=200k`；`computeKeepFromIndex` 用 `minOf(rawLimit, SAFE_CAP)` 收敛历史预算——标称窗口再大，折叠触发线不超过 96k，杜绝"超大 contextTokens 把阈值撑到无穷大、永不折叠"。
- `ApiContextAssembler`：`budget` 收敛到 `[0, MAX_CONTEXT_BUDGET]`。
- `CompactionManager`：每次压缩打印日志（折叠/保留条数、摘要长度、压缩前估算 token），**让压缩从 0 条可观测变为可 grep**。

**方案 C · 健壮性**
- `ProviderClient` 新增 `TransientHttpException(IOException)` 承载 5xx（含 Cloudflare 524 origin timeout），被 Runner 现有网络重试路径统一退避，不再裸抛中断 agent。
- `AnthropicApi`/`ResponsesApi`/`ProviderClient` 的 5xx 抛出点改走 `transientHttpException`。
- `HarnessProviderRunner`：命中"模型不支持图片输入(HTTP 400)"时剥离全部图片降级重试一次（VisionFallback）。

## Testing
- 本地沙箱缺 `android-37` SDK/`sdkmanager`，全量编译与单测交由 **CI（taixudev-build.yml Test task）** 作为证据。
- 建议 CI 通过 + 装 TaiXuDev 后回归：长会话观察是否出现 `ContextCompaction` 日志、模型是否不再输出 `\/` 夹带与截断 JSON；524/图片场景是否自动重试/降级。

## Risks
- `SAFE_GENERATION_CAP=96k` 对真正长上下文模型（GPT-4/Claude 200k）会**更早触发折叠**——这是刻意取舍（保 flash 稳定 vs 长模型容量），如需要可再提 PR 调参或按模型族分档。
- 5xx 走 IOException 重试：服务端持续 5xx 会在重试上限内退避，超限仍失败并落 error state。
- 图片 400 降级：仅剥离图片重试一次，400 与图片无关则不触发。